### PR TITLE
fixes typos and touch problems

### DIFF
--- a/assets/ui/i18n_de.properties
+++ b/assets/ui/i18n_de.properties
@@ -12,7 +12,7 @@ Boss1Dialog2.1=[BROWN]Minotaure[]: Oh, und mein kleiner Freund hier ist natürli
 Boss1Dialog3.1=Du hast den Minotauren besiegt, aber deine Freundin scheint nicht mehr bei ihm zu sein.\n\
 Ein lautes Geräusch ertönt in der Ferne.\n\
 Ob sich vielleicht ein neuer Weg in der Höhle offenbart?
-Boss1Dialog3.2=Die ist leider bereits schon das Ende von der ersten Version von Quilly's Abenteuer.\n\
+Boss1Dialog3.2=Dies ist leider bereits schon das Ende von der ersten Version von Quilly's Abenteuer.\n\
 Wenn es dir Spaß gemacht hat, dann lass es mich bitte unter [RED]quillraven@gmail.com[] wissen.\n\
 Vielen Dank fürs Spielen!
 continue=Fortfahren

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/RenderSystem.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/RenderSystem.kt
@@ -3,6 +3,7 @@ package com.github.quillraven.quillysadventure.ecs.system
 import com.badlogic.ashley.core.Engine
 import com.badlogic.ashley.core.Entity
 import com.badlogic.ashley.systems.SortedIteratingSystem
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.graphics.OrthographicCamera
@@ -94,7 +95,7 @@ class RenderSystem(
         batch.use {
             if (vignetteActive) {
                 // set mandatory uniforms for vignette effect
-                resolutionVector.set(gameViewPort.screenWidth.toFloat(), gameViewPort.screenHeight.toFloat())
+                resolutionVector.set(Gdx.graphics.width.toFloat(), Gdx.graphics.height.toFloat())
                 batch.shader.setUniformf("resolution", resolutionVector)
                 batch.shader.setUniformf("radius", sepiaVignetteRadius)
             } else if (colorActive) {
@@ -204,9 +205,9 @@ class RenderSystem(
         vignetteActive = false
     }
 
-    fun setColorShader() {
+    fun setColorShader(grayness: Float = 1f) {
         batch.shader = shaderPrograms[ShaderType.COLOR]
         colorActive = true
-        grayness = 1f
+        this.grayness = grayness
     }
 }

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/EndScreen.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/EndScreen.kt
@@ -81,7 +81,7 @@ class EndScreen(
 
         // change renderer to grayScale
         grayness = 0f
-        renderSystem.setColorShader()
+        renderSystem.setColorShader(grayness)
 
         // disable player input
         gameEventManager.disablePlayerInput()
@@ -133,7 +133,7 @@ class EndScreen(
             ani.mode = Animation.PlayMode.LOOP
         }
 
-        if (Gdx.input.isTouched) {
+        if (Gdx.input.justTouched()) {
             game.setScreen<MenuScreen>()
         }
     }

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/LoadingScreen.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/LoadingScreen.kt
@@ -247,7 +247,7 @@ class LoadingScreen(
             )
         }
 
-        if (loaded && Gdx.input.isTouched) {
+        if (loaded && Gdx.input.justTouched()) {
             // go to the menu screen once everything is loaded
             // game.setScreen<MenuScreen>()
             game.setScreen<MenuScreen>()


### PR DESCRIPTION
- fixes a minor typo in the last dialog message
- fixes the issue that screens got switched on android even though the user did not really touch the display. It took over the touch state from the previous screen
- fixes the endscreen to no longer start in grayscale mode for the first frame
- fixes the vignette effect of the sepia shader to be consistent across different resolutions