### PR TITLE
Feature/save game state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ Thumbs.db
 /buildSrc/build/
 
 android/local.properties
+/android/release/

--- a/assets/map/map2.tmx
+++ b/assets/map/map2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="right-up" compressionlevel="0" width="32" height="96" tilewidth="16" tileheight="16" infinite="0" nextlayerid="35" nextobjectid="116">
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-up" compressionlevel="0" width="32" height="96" tilewidth="16" tileheight="16" infinite="0" nextlayerid="35" nextobjectid="117">
  <tileset firstgid="1" source="tilesets.tsx"/>
  <layer id="28" name="bgd0" width="32" height="96">
   <data encoding="base64" compression="zlib">
@@ -151,6 +151,11 @@
   <object id="112" name="TriggerMap2.setupBossPitRight" x="430.25" y="1514.25" width="58.5" height="20.5">
    <properties>
     <property name="TriggerReactOnCollision" type="bool" value="true"/>
+   </properties>
+  </object>
+  <object id="116" name="TriggerMap2.setupAfterBoss" x="76.25" y="1299.83" width="49.5" height="31">
+   <properties>
+    <property name="TriggerReactOnCollision" type="bool" value="false"/>
    </properties>
   </object>
  </objectgroup>

--- a/assets/ui/i18n.properties
+++ b/assets/ui/i18n.properties
@@ -1,4 +1,6 @@
 armor=Armor
+backToMenu.info=Do you really want to go back to the menu? Your progress will be lost until the last \
+checkpoint that you have reached or until the last map that you have entered.
 Boss1Dialog1.1=[BROWN]Minotaur[]: Who is there?\n\
 [RED]Quilly[]: Are you the one who kidnapped my girlfriend?\n\
 [BROWN]Minotaur[]: *harharhar*, then you are the little worm of whom the girl was talking about all the time.

--- a/assets/ui/i18n.properties
+++ b/assets/ui/i18n.properties
@@ -16,6 +16,9 @@ Time to continue your search!
 Boss1Dialog3.2=This is already the end of version one of Quilly's Adventure.\n\
 If you enjoyed it then please let me know at [RED]quillraven@gmail.com[].\n\
 Thanks for playing!
+clearGameState.info=You already started a game before. If you want to continue the game please click on \
+[RED]Continue[] in the menu. If you want to start a new game and delete your old \
+progress then click on [RED]Yes[].
 continue=Continue
 credits=Credits
 credits.info=Special thanks to [RED]DRSchlaubi[] for his great assistance throughout the project with Kotlin and Gradle.\
@@ -56,6 +59,7 @@ map.name.MAP1=Path to cave
 map.name.MAP2=Cave
 music=Music
 newGame=New Game
+no=No
 quitGame=Quit Game
 requiresLvl3=requires Level 3
 skills=[BROWN]Skills[]
@@ -94,3 +98,4 @@ Use the attack button or CTRL key to make Quilly [RED]attack[].\n\n\
 Be careful of the blue slimes ahead! They will attack you.
 xp=Experience
 xpAbbreviation=XP
+yes=Yes

--- a/assets/ui/i18n_de.properties
+++ b/assets/ui/i18n_de.properties
@@ -1,4 +1,6 @@
 armor=Rüstung
+backToMenu.info=Willst du wirklich zurück ins Menü? Dein Fortschritt ist verloren bis zum letzten \
+Speicherpunkt oder zur letzten Karte, die du betreten hast.
 Boss1Dialog1.1=[BROWN]Minotaure[]: Schau an, wen haben wir denn da?\n\
 [RED]Quilly[]: Bist du derjenige, der meine Freundin entführt hat?\n\
 [BROWN]Minotaure[]: *harharhar*, dann bist du also der kleine Wurm, von dem \

--- a/assets/ui/i18n_de.properties
+++ b/assets/ui/i18n_de.properties
@@ -16,6 +16,9 @@ Zeit, deine Suche fortzusetzen!
 Boss1Dialog3.2=Dies ist leider bereits schon das Ende von der ersten Version von Quilly's Abenteuer.\n\
 Wenn es dir Spaß gemacht hat, dann lass es mich bitte unter [RED]quillraven@gmail.com[] wissen.\n\
 Vielen Dank fürs Spielen!
+clearGameState.info=Du hast bereits ein Spiel begonnen. Wenn du es fortsetzen möchtest, dann klicke bitte auf \
+[RED]Fortsetzen[] im Menü. Wenn du ein neues Spiel beginnen möchtest und den aktuellen \
+Fortschritt löschen möchtest, dann klicke auf [RED]Ja[].
 continue=Fortfahren
 credits=Danksagungen
 credits.info=Ein besonderes Dankeschön geht an [RED]DRSchlaubi[] für seine großartige Unterstützung während des ganzen Projektes mit Kotlin und Gradle. \
@@ -59,6 +62,7 @@ map.name.MAP1=Weg zur Höhle
 map.name.MAP2=Höhle
 music=Musik
 newGame=Neues Spiel
+no=Nein
 quitGame=Spiel Beenden
 requiresLvl3=benötigt Stufe 3
 skills=[BROWN]Fähigkeiten[]
@@ -97,3 +101,4 @@ Benutze den Angriffsknopf oder STRG um [RED]anzugreifen[].\n\n\
 Hüte dich vor den blauen Schleimen! Sie werden dich angreifen.
 xp=Erfahrung
 xpAbbreviation=ERF
+yes=Ja

--- a/assets/ui/i18n_en.properties
+++ b/assets/ui/i18n_en.properties
@@ -1,4 +1,6 @@
 armor=Armor
+backToMenu.info=Do you really want to go back to the menu? Your progress will be lost until the last \
+checkpoint that you have reached or until the last map that you have entered.
 Boss1Dialog1.1=[BROWN]Minotaur[]: Who is there?\n\
 [RED]Quilly[]: Are you the one who kidnapped my girlfriend?\n\
 [BROWN]Minotaur[]: *harharhar*, then you are the little worm of whom the girl was talking about all the time.

--- a/assets/ui/i18n_en.properties
+++ b/assets/ui/i18n_en.properties
@@ -16,6 +16,9 @@ Time to continue your search!
 Boss1Dialog3.2=This is already the end of version one of Quilly's Adventure.\n\
 If you enjoyed it then please let me know at [RED]quillraven@gmail.com[].\n\
 Thanks for playing!
+clearGameState.info=You already started a game before. If you want to continue the game please click on \
+[RED]Continue[] in the menu. If you want to start a new game and delete your old \
+progress then click on [RED]Yes[].
 continue=Continue
 credits=Credits
 credits.info=Special thanks to [RED]DRSchlaubi[] for his great assistance throughout the project with Kotlin and Gradle.\
@@ -56,6 +59,7 @@ map.name.MAP1=Path to cave
 map.name.MAP2=Cave
 music=Music
 newGame=New Game
+no=No
 quitGame=Quit Game
 requiresLvl3=requires Level 3
 skills=[BROWN]Skills[]
@@ -94,3 +98,4 @@ Use the attack button or CTRL key to make Quilly [RED]attack[].\n\n\
 Be careful of the blue slimes ahead! They will attack you.
 xp=Experience
 xpAbbreviation=XP
+yes=Yes

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/Main.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/Main.kt
@@ -46,7 +46,7 @@ private val LOG = logger<Main>()
 
 const val VIRTUAL_W = 1280
 const val VIRTUAL_H = 720
-private const val PREF_NAME = "quilly-jumper"
+private const val PREF_NAME = "quilly-adventure"
 const val UNIT_SCALE = 1 / 32f
 const val FIXTURE_TYPE_FOOT_SENSOR = 1
 const val FIXTURE_TYPE_AGGRO_SENSOR = 2 shl 0

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/PhysicContactListener.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/PhysicContactListener.kt
@@ -47,7 +47,9 @@ class PhysicContactListener : ContactListener {
      * Therefore two additional checks are added that it is really a relevant **collision entity** with a certain **type**.
      */
     private fun isRemoved(srcEntity: Entity, collEntity: Entity) =
-        srcEntity.isRemoved() || collEntity.isRemoved() || srcEntity[CollisionComponent.mapper] == null || collEntity[EntityTypeComponent.mapper] == null
+        srcEntity.isRemoved() || collEntity.isRemoved()
+                || srcEntity[CollisionComponent.mapper] == null
+                || collEntity[EntityTypeComponent.mapper] == null
 
     /**
      * @param srcFixture the fixture of the entity for which you want to update the collision data

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/PhysicContactListener.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/PhysicContactListener.kt
@@ -46,8 +46,8 @@ class PhysicContactListener : ContactListener {
      * time to time and entities are not 100% cleaned removed at that time.
      * Therefore two additional checks are added that it is really a relevant **collision entity** with a certain **type**.
      */
-    private fun isRemoved(entity: Entity) =
-        entity.isRemoved() || entity[CollisionComponent.mapper] == null || entity[EntityTypeComponent.mapper] == null
+    private fun isRemoved(srcEntity: Entity, collEntity: Entity) =
+        srcEntity.isRemoved() || collEntity.isRemoved() || srcEntity[CollisionComponent.mapper] == null || collEntity[EntityTypeComponent.mapper] == null
 
     /**
      * @param srcFixture the fixture of the entity for which you want to update the collision data
@@ -56,7 +56,7 @@ class PhysicContactListener : ContactListener {
      * @param collEntity the colliding entity from [endContact] method
      */
     private fun removeCollisionData(srcFixture: Fixture, srcEntity: Entity, collFixture: Fixture, collEntity: Entity) {
-        if (isRemoved(srcEntity) || isRemoved(collEntity)) {
+        if (isRemoved(srcEntity, collEntity)) {
             return
         }
 

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ai/PlayerState.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ai/PlayerState.kt
@@ -31,30 +31,27 @@ enum class PlayerState(
                     entity.attackCmp.order == AttackOrder.START -> changeState(ATTACK)
                     entity.jumpCmp.order == JumpOrder.JUMP -> changeState(JUMP)
                     entity.moveCmp.order != MoveOrder.NONE -> changeState(RUN)
-                    entity.physicCmp.body.linearVelocity.y <= 0f && entity.collCmp.numGroundContacts == 0 ->
-                        changeState(FALL)
+                    isFalling(entity.physicCmp, entity.collCmp) -> changeState(FALL)
                 }
             }
         }
     },
     RUN(AnimationType.RUN) {
         override fun update(entity: Entity) {
-            val velocity = entity.physicCmp.body.linearVelocity
+            val physicCmp = entity.physicCmp
+            val velocity = physicCmp.body.linearVelocity
             with(entity.stateCmp.stateMachine) {
                 when {
                     entity.abilityCmp.order == CastOrder.BEGIN_CAST -> changeState(CAST)
                     entity.attackCmp.order == AttackOrder.START -> changeState(ATTACK)
                     entity.jumpCmp.order == JumpOrder.JUMP -> changeState(JUMP)
-                    velocity.y <= 0f && entity.collCmp.numGroundContacts == 0 -> changeState(FALL)
+                    isFalling(physicCmp, entity.collCmp) -> changeState(FALL)
                     entity.moveCmp.order == MoveOrder.NONE && abs(velocity.x) <= 0.5f -> changeState(IDLE)
                 }
             }
         }
     },
     JUMP(AnimationType.JUMP, Animation.PlayMode.NORMAL) {
-        private fun isFalling(physic: PhysicComponent, collision: CollisionComponent) =
-            physic.body.linearVelocity.y <= 0f && collision.numGroundContacts == 0
-
         override fun update(entity: Entity) {
             val collision = entity.collCmp
             with(entity.stateCmp) {
@@ -134,5 +131,8 @@ enum class PlayerState(
             super.exit(entity)
             entity.aniCmp.animationSpeed = 1f
         }
-    }
+    };
+
+    fun isFalling(physic: PhysicComponent, collision: CollisionComponent) =
+        physic.body.linearVelocity.y < 0f && collision.numGroundContacts == 0
 }

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/EcsUtils.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/EcsUtils.kt
@@ -430,6 +430,9 @@ fun Engine.portalTarget(
         with<PortalComponent> {
             this.portalID = portalID
         }
+        with<TmxMapComponent> {
+            id = portalID
+        }
     }
 }
 

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/EcsUtils.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/EcsUtils.kt
@@ -48,6 +48,7 @@ import com.github.quillraven.quillysadventure.ecs.component.RenderComponent
 import com.github.quillraven.quillysadventure.ecs.component.StateComponent
 import com.github.quillraven.quillysadventure.ecs.component.StatsComponent
 import com.github.quillraven.quillysadventure.ecs.component.TakeDamageComponent
+import com.github.quillraven.quillysadventure.ecs.component.TmxMapComponent
 import com.github.quillraven.quillysadventure.ecs.component.TransformComponent
 import com.github.quillraven.quillysadventure.ecs.component.TriggerComponent
 import com.github.quillraven.quillysadventure.ecs.component.physicCmp
@@ -282,7 +283,13 @@ fun Engine.character(
     }
 }
 
-fun Engine.item(cfg: ItemCfg, world: World, posX: Float, posY: Float): Entity {
+fun Engine.item(
+    cfg: ItemCfg,
+    world: World,
+    posX: Float,
+    posY: Float,
+    compData: EngineEntity.() -> Unit = { Unit }
+): Entity {
     return this.entity {
         // transform
         with<TransformComponent> {
@@ -325,6 +332,8 @@ fun Engine.item(cfg: ItemCfg, world: World, posX: Float, posY: Float): Entity {
         with<EntityTypeComponent> {
             this.type = EntityType.ITEM
         }
+
+        this.compData()
     }
 }
 
@@ -463,6 +472,10 @@ fun Engine.portal(
             this.targetOffsetX = targetOffsetX
             this.targetPortal = targetPortal
         }
+        // tmx map info
+        with<TmxMapComponent> {
+            id = portalID
+        }
     }
 }
 
@@ -600,6 +613,7 @@ fun Engine.missile(
 }
 
 fun Engine.trigger(
+    triggerID: Int,
     triggerSetupFunctionName: String,
     reactOnCollision: Boolean,
     world: World,
@@ -625,6 +639,10 @@ fun Engine.trigger(
             newTrigger.active = false
             withDefaultStaticPhysic(world, shape)
             with<CollisionComponent>()
+        }
+
+        with<TmxMapComponent> {
+            id = triggerID
         }
     }
 }

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/component/AbilityComponent.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/component/AbilityComponent.kt
@@ -24,6 +24,15 @@ class AbilityComponent : Component, Pool.Poolable {
 
     fun canCast() = abilityToCastIdx >= 0 && abilityToCastIdx < abilities.size && abilities[abilityToCastIdx].canCast()
 
+    fun hasAbility(abilityEffect: AbilityEffect): Boolean {
+        abilities.forEach { ability ->
+            if (ability.effect == abilityEffect) {
+                return true
+            }
+        }
+        return false
+    }
+
     fun addAbility(entity: Entity, abilityEffect: AbilityEffect) {
         abilities.forEach { ability ->
             if (ability.effect == abilityEffect) {

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/component/SaveComponent.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/component/SaveComponent.kt
@@ -1,0 +1,8 @@
+package com.github.quillraven.quillysadventure.ecs.component
+
+import com.badlogic.ashley.core.Component
+import com.badlogic.gdx.utils.Pool
+
+class SaveComponent : Component, Pool.Poolable {
+    override fun reset() = Unit
+}

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/component/TmxMapComponent.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/component/TmxMapComponent.kt
@@ -1,0 +1,17 @@
+package com.github.quillraven.quillysadventure.ecs.component
+
+import com.badlogic.ashley.core.Component
+import com.badlogic.gdx.utils.Pool
+import ktx.ashley.mapperFor
+
+class TmxMapComponent : Component, Pool.Poolable {
+    var id = -1
+
+    override fun reset() {
+        id = -1
+    }
+
+    companion object {
+        val mapper = mapperFor<TmxMapComponent>()
+    }
+}

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/PlayerCollisionSystem.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/PlayerCollisionSystem.kt
@@ -12,6 +12,7 @@ import com.github.quillraven.quillysadventure.ecs.component.CollisionComponent
 import com.github.quillraven.quillysadventure.ecs.component.EntityType
 import com.github.quillraven.quillysadventure.ecs.component.PlayerComponent
 import com.github.quillraven.quillysadventure.ecs.component.RemoveComponent
+import com.github.quillraven.quillysadventure.ecs.component.SaveComponent
 import com.github.quillraven.quillysadventure.ecs.component.collCmp
 import com.github.quillraven.quillysadventure.ecs.component.heal
 import com.github.quillraven.quillysadventure.ecs.component.physicCmp
@@ -36,13 +37,13 @@ import ktx.log.logger
 private val LOG = logger<PlayerCollisionSystem>()
 
 class PlayerCollisionSystem(
-        private val mapManager: MapManager,
-        private val audioService: AudioService,
-        private val gameEventManager: GameEventManager,
-        private val bundle: I18NBundle
+    private val mapManager: MapManager,
+    private val audioService: AudioService,
+    private val gameEventManager: GameEventManager,
+    private val bundle: I18NBundle
 ) :
-        IteratingSystem(allOf(PlayerComponent::class, CollisionComponent::class).get()), MapChangeListener,
-        GameEventListener {
+    IteratingSystem(allOf(PlayerComponent::class, CollisionComponent::class).get()), MapChangeListener,
+    GameEventListener {
     private val itemInfoBuilder = StringBuilder(64)
     private var lastSavepoint: Entity? = null
 
@@ -97,6 +98,8 @@ class PlayerCollisionSystem(
                             // also heal the player
                             val stats = entity.statsCmp
                             entity.heal(engine, stats.maxLife, stats.maxMana)
+                            // and save the game
+                            entity.add(engine.createComponent(SaveComponent::class.java))
                         }
                     }
                     EntityType.TRIGGER -> {
@@ -139,14 +142,14 @@ class PlayerCollisionSystem(
         // show information to player about the changed stats
         with(player.transfCmp) {
             engine.floatingText(
-                    position.x,
-                    position.y + size.y,
-                    FontType.LARGE,
-                    itemInfoBuilder,
-                    Color.SCARLET,
-                    0f,
-                    -0.6f,
-                    4f
+                position.x,
+                position.y + size.y,
+                FontType.LARGE,
+                itemInfoBuilder,
+                Color.SCARLET,
+                0f,
+                -0.6f,
+                4f
             )
         }
 

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/PlayerCollisionSystem.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/PlayerCollisionSystem.kt
@@ -79,6 +79,8 @@ class PlayerCollisionSystem(
                                     }
                                 } else {
                                     mapManager.setMap(targetMap, targetPortal, targetOffsetX)
+                                    // and save the game
+                                    entity.add(engine.createComponent(SaveComponent::class.java))
                                 }
                                 // ignore any other collisions for that frame because the player got moved to a new map
                                 return

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/SaveSystem.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/SaveSystem.kt
@@ -1,0 +1,90 @@
+package com.github.quillraven.quillysadventure.ecs.system
+
+import com.badlogic.ashley.core.Entity
+import com.badlogic.ashley.systems.IteratingSystem
+import com.badlogic.gdx.Preferences
+import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.utils.Array
+import com.badlogic.gdx.utils.IntArray
+import com.badlogic.gdx.utils.IntMap
+import com.github.quillraven.quillysadventure.ability.AbilityEffect
+import com.github.quillraven.quillysadventure.ecs.component.PlayerComponent
+import com.github.quillraven.quillysadventure.ecs.component.SaveComponent
+import com.github.quillraven.quillysadventure.ecs.component.abilityCmp
+import com.github.quillraven.quillysadventure.ecs.component.playerCmp
+import com.github.quillraven.quillysadventure.ecs.component.statsCmp
+import com.github.quillraven.quillysadventure.map.MapManager
+import com.github.quillraven.quillysadventure.map.MapType
+import ktx.ashley.allOf
+import ktx.collections.set
+import ktx.math.vec2
+import ktx.preferences.flush
+import ktx.preferences.set
+
+const val KEY_SAVE_STATE = "saveState"
+
+class SaveState {
+    lateinit var currentMap: MapType
+    lateinit var mapEntities: IntMap<IntArray>
+    lateinit var tutorials: IntArray
+    lateinit var checkpoint: Vector2
+    var abilityToCastIdx = -1
+    lateinit var abilities: Array<AbilityEffect>
+    var damage = 0f
+    var life = 0f
+    var maxLife = 0f
+    var mana = 0f
+    var maxMana = 0f
+    var armor = 0f
+    var level = 0
+    var xp = 0
+}
+
+class SaveSystem(
+    private val preferences: Preferences,
+    private val mapManager: MapManager
+) : IteratingSystem(allOf(PlayerComponent::class, SaveComponent::class).get()) {
+    private val saveState = SaveState().apply {
+        mapEntities = IntMap<IntArray>()
+        tutorials = IntArray()
+        checkpoint = vec2()
+        abilities = Array<AbilityEffect>()
+    }
+
+    override fun processEntity(entity: Entity, deltaTime: Float) {
+        preferences.flush {
+            this[KEY_SAVE_STATE] = saveState.apply {
+                // map information
+                currentMap = mapManager.currentMap()
+                mapEntities.clear()
+                mapManager.storeMapEntities(currentMap)
+                mapManager.mapEntityCache.forEach { (mapType, entities) ->
+                    mapEntities[mapType.ordinal] = IntArray(entities)
+                }
+                // player component
+                tutorials.clear()
+                val playerCmp = entity.playerCmp
+                playerCmp.tutorials.forEach { tutorials.add(it.ordinal) }
+                checkpoint = playerCmp.checkpoint
+                // ability component
+                abilities.clear()
+                val abilityCmp = entity.abilityCmp
+                abilityToCastIdx = abilityCmp.abilityToCastIdx
+                abilityCmp.abilities.forEach { abilities.add(it.effect) }
+                // stats component
+                val statsCmp = entity.statsCmp
+                this.damage = statsCmp.damage
+                this.life = statsCmp.life
+                this.maxLife = statsCmp.maxLife
+                this.mana = statsCmp.mana
+                this.maxMana = statsCmp.maxMana
+                this.armor = statsCmp.armor
+                this.level = statsCmp.level
+                this.xp = statsCmp.xp
+            }
+        }
+
+        // remove component since the save is done
+        entity.remove(SaveComponent::class.java)
+    }
+}

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/TriggerSystem.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ecs/system/TriggerSystem.kt
@@ -25,10 +25,16 @@ class TriggerSystem(private val gameEventManager: GameEventManager) :
 
     override fun processEntity(entity: Entity, deltaTime: Float) {
         with(entity.triggerCmp) {
-            if (trigger.active && trigger.update(deltaTime)) {
-                // trigger is active and completed all of its actions -> remove it
-                entity.add(engine.createComponent(RemoveComponent::class.java))
-                gameEventManager.dispatchTriggerFinishedEvent(trigger)
+            if (trigger.active) {
+                // trigger is active
+                if (!trigger.checkConditions()) {
+                    // but conditions are not met -> set to inactive
+                    trigger.active = false
+                } else if (trigger.update(deltaTime)) {
+                    // conditions met and completed all of its actions -> remove it
+                    entity.add(engine.createComponent(RemoveComponent::class.java))
+                    gameEventManager.dispatchTriggerFinishedEvent(trigger)
+                }
             }
         }
     }

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/map/MapManager.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/map/MapManager.kt
@@ -62,6 +62,7 @@ class MapManager(
         val currentMap = mapCache[currentMapType]
         if (currentMap != null) {
             storeMapEntities(currentMapType)
+            LOG.debug { "Storing map entities of map $currentMapType: ${mapEntityCache[currentMapType]}" }
 
             gameEventManager.dispatchBeforeMapChangeEvent()
             // remove all non-player entities of the current loaded map
@@ -230,7 +231,11 @@ class MapManager(
             try {
                 // retrieve and validate portal properties
                 if (mapObj.type == "PortalTarget") {
-                    ecsEngine.portalTarget(mapObj.x * UNIT_SCALE, mapObj.y * UNIT_SCALE, mapObj.id)
+                    ecsEngine.portalTarget(
+                        mapObj.x * UNIT_SCALE,
+                        mapObj.y * UNIT_SCALE,
+                        mapObj.id
+                    )
                 } else {
                     val targetMap = MapType.valueOf(mapObj.property(PROPERTY_TARGET_MAP, ""))
                     val targetPortal = mapObj.property(PROPERTY_TARGET_PORTAL_ID, -1)

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/map/MapManager.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/map/MapManager.kt
@@ -161,7 +161,7 @@ class MapManager(
 
     private fun entityInCache(mapObject: MapObject, map: Map): Boolean {
         val entities = mapEntityCache[map.type]
-        return entities != null && entities.contains(mapObject.id)
+        return entities == null || entities.contains(mapObject.id)
     }
 
     private fun createCharacterEntities(map: Map, layer: String) {

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/map/MapManager.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/map/MapManager.kt
@@ -6,7 +6,9 @@ import com.badlogic.ashley.core.Entity
 import com.badlogic.ashley.utils.ImmutableArray
 import com.badlogic.gdx.assets.AssetManager
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.maps.MapObject
 import com.badlogic.gdx.physics.box2d.World
+import com.badlogic.gdx.utils.IntArray
 import com.github.quillraven.quillysadventure.UNIT_SCALE
 import com.github.quillraven.quillysadventure.assets.get
 import com.github.quillraven.quillysadventure.configuration.Character
@@ -16,6 +18,7 @@ import com.github.quillraven.quillysadventure.configuration.ItemConfigurations
 import com.github.quillraven.quillysadventure.ecs.character
 import com.github.quillraven.quillysadventure.ecs.component.EntityType
 import com.github.quillraven.quillysadventure.ecs.component.RemoveComponent
+import com.github.quillraven.quillysadventure.ecs.component.TmxMapComponent
 import com.github.quillraven.quillysadventure.ecs.component.physicCmp
 import com.github.quillraven.quillysadventure.ecs.component.playerCmp
 import com.github.quillraven.quillysadventure.ecs.component.transfCmp
@@ -27,6 +30,7 @@ import com.github.quillraven.quillysadventure.ecs.portalTarget
 import com.github.quillraven.quillysadventure.ecs.scenery
 import com.github.quillraven.quillysadventure.ecs.trigger
 import com.github.quillraven.quillysadventure.event.GameEventManager
+import ktx.ashley.get
 import ktx.log.logger
 import ktx.tiled.id
 import ktx.tiled.property
@@ -39,27 +43,25 @@ import java.util.*
 private val LOG = logger<MapManager>()
 
 class MapManager(
-        private val assets: AssetManager,
-        private val world: World,
-        private val rayHandler: RayHandler,
-        private val ecsEngine: Engine,
-        private val characterConfigurations: CharacterConfigurations,
-        private val itemConfigurations: ItemConfigurations,
-        private val playerEntities: ImmutableArray<Entity>,
-        private val gameEventManager: GameEventManager
+    private val assets: AssetManager,
+    private val world: World,
+    private val rayHandler: RayHandler,
+    private val ecsEngine: Engine,
+    private val characterConfigurations: CharacterConfigurations,
+    private val itemConfigurations: ItemConfigurations,
+    private val playerEntities: ImmutableArray<Entity>,
+    private val gameEventManager: GameEventManager
 ) {
     private var currentMapType = MapType.TEST_MAP
     private val mapCache = EnumMap<MapType, Map>(MapType::class.java)
+    val mapEntityCache = EnumMap<MapType, IntArray>(MapType::class.java)
 
     fun currentMap() = currentMapType
 
     fun setMap(mapType: MapType, targetPortal: Int = -1, targetOffsetX: Int = -1) {
         val currentMap = mapCache[currentMapType]
         if (currentMap != null) {
-            //TODO
-            // 1) save current entity data to a file
-            // 2) check for new map if there is already existing data in the save file.
-            //    Otherwise, load data from TiledMap.tmx file
+            storeMapEntities(currentMapType)
 
             gameEventManager.dispatchBeforeMapChangeEvent()
             // remove all non-player entities of the current loaded map
@@ -93,7 +95,26 @@ class MapManager(
         }
     }
 
-    private fun movePlayer(x: Float, y: Float) {
+    fun storeMapEntities(mapType: MapType) {
+        mapEntityCache.computeIfAbsent(mapType) { IntArray(32) }.apply {
+            this.clear()
+            ecsEngine.entities.forEach { entity ->
+                val tmxMapCmp = entity[TmxMapComponent.mapper]
+                if (tmxMapCmp != null) {
+                    this.add(tmxMapCmp.id)
+                }
+            }
+        }
+    }
+
+    fun storeMapEntities(mapType: MapType, entities: IntArray) {
+        mapEntityCache.computeIfAbsent(mapType) { IntArray(32) }.apply {
+            this.clear()
+            this.addAll(entities)
+        }
+    }
+
+    fun movePlayer(x: Float, y: Float) {
         playerEntities.forEach { player ->
             player.physicCmp.body.run {
                 setTransform(x, y, 0f)
@@ -138,16 +159,27 @@ class MapManager(
         }
     }
 
+    private fun entityInCache(mapObject: MapObject, map: Map): Boolean {
+        val entities = mapEntityCache[map.type]
+        return entities != null && entities.contains(mapObject.id)
+    }
+
     private fun createCharacterEntities(map: Map, layer: String) {
         map.forEachMapObject(layer) { mapObj ->
+            if (!entityInCache(mapObj, map)) return@forEachMapObject
+
             try {
                 val charKey = Character.valueOf(mapObj.name)
                 ecsEngine.character(
-                        characterConfigurations[charKey],
-                        world,
-                        mapObj.x * UNIT_SCALE,
-                        mapObj.y * UNIT_SCALE
-                )
+                    characterConfigurations[charKey],
+                    world,
+                    mapObj.x * UNIT_SCALE,
+                    mapObj.y * UNIT_SCALE
+                ) {
+                    with<TmxMapComponent> {
+                        id = mapObj.id
+                    }
+                }
             } catch (e: IllegalArgumentException) {
                 LOG.error(e) {
                     "Invalid name specified for object " +
@@ -166,14 +198,20 @@ class MapManager(
 
     private fun createItemEntities(map: Map) {
         map.forEachMapObject(LAYER_ITEM) { mapObj ->
+            if (!entityInCache(mapObj, map)) return@forEachMapObject
+
             try {
                 val itemKey = Item.valueOf(mapObj.name)
                 ecsEngine.item(
-                        itemConfigurations[itemKey],
-                        world,
-                        mapObj.x * UNIT_SCALE,
-                        mapObj.y * UNIT_SCALE
-                )
+                    itemConfigurations[itemKey],
+                    world,
+                    mapObj.x * UNIT_SCALE,
+                    mapObj.y * UNIT_SCALE
+                ) {
+                    with<TmxMapComponent> {
+                        id = mapObj.id
+                    }
+                }
             } catch (e: IllegalArgumentException) {
                 LOG.error(e) {
                     "Invalid name specified for object " +
@@ -187,6 +225,8 @@ class MapManager(
 
     private fun createPortalEntities(map: Map) {
         map.forEachMapObject(LAYER_PORTAL) { mapObj ->
+            if (!entityInCache(mapObj, map)) return@forEachMapObject
+
             try {
                 // retrieve and validate portal properties
                 if (mapObj.type == "PortalTarget") {
@@ -214,14 +254,14 @@ class MapManager(
 
                     // create portal entity
                     ecsEngine.portal(
-                            world,
-                            mapObj.shape,
-                            mapObj.id,
-                            mapObj.property(PROPERTY_PORTAL_ACTIVE, true),
-                            targetMap,
-                            targetPortal,
-                            targetOffsetX,
-                            mapObj.property(PROPERTY_FLIP_PARTICLE_FX, false)
+                        world,
+                        mapObj.shape,
+                        mapObj.id,
+                        mapObj.property(PROPERTY_PORTAL_ACTIVE, true),
+                        targetMap,
+                        targetPortal,
+                        targetOffsetX,
+                        mapObj.property(PROPERTY_FLIP_PARTICLE_FX, false)
                     )
                 }
             } catch (e: IllegalArgumentException) {
@@ -240,6 +280,8 @@ class MapManager(
 
     private fun createTriggers(map: Map) {
         map.forEachMapObject(LAYER_TRIGGER) { mapObj ->
+            if (!entityInCache(mapObj, map)) return@forEachMapObject
+
             val triggerSetupFunction = mapObj.name
             if (triggerSetupFunction.isBlank()) {
                 LOG.error {
@@ -259,10 +301,11 @@ class MapManager(
             }
 
             ecsEngine.trigger(
-                    triggerSetupFunction,
-                    mapObj.property(PROPERTY_TRIGGER_REACT_ON_COLLISION, false),
-                    world,
-                    mapObj.shape
+                mapObj.id,
+                triggerSetupFunction,
+                mapObj.property(PROPERTY_TRIGGER_REACT_ON_COLLISION, false),
+                world,
+                mapObj.shape
             )
         }
     }
@@ -276,9 +319,9 @@ class MapManager(
             rayHandler.setBlurNum(2)
             // create point light entity
             ecsEngine.globalLight(
-                    rayHandler,
-                    map.property(PROPERTY_SUN_COLOR, Color.WHITE),
-                    map.property(PROPERTY_SHADOW_ANGLE, 0f)
+                rayHandler,
+                map.property(PROPERTY_SUN_COLOR, Color.WHITE),
+                map.property(PROPERTY_SHADOW_ANGLE, 0f)
             )
         } else {
             rayHandler.setBlur(false)

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/GameScreen.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/GameScreen.kt
@@ -165,6 +165,7 @@ class GameScreen(
             player.abilityCmp.run {
                 this.abilityToCastIdx = saveState.abilityToCastIdx
                 if (this.abilityToCastIdx == 0) {
+                    hud.statsWidget.activateSkill(0)
                     hud.skillButton.style =
                         hud.skin.get(
                             ImageButtonStyles.FIREBALL.name,

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/GameScreen.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/GameScreen.kt
@@ -151,8 +151,8 @@ class GameScreen(
         }
     }
 
-    private fun updatePlayerHUD(entity: Entity) {
-        with(entity.statsCmp) {
+    private fun updatePlayerHUD(player: Entity) {
+        with(player.statsCmp) {
             hud.infoWidget.resetHudValues(this.life / this.maxLife, this.mana / this.maxMana)
             hud.statsWidget.updateLevel(levelTxt, this.level)
                 .updateExperience(
@@ -165,6 +165,18 @@ class GameScreen(
                 .updateMana(manaTxt, this.mana.toInt(), this.maxMana.toInt())
                 .updateDamage(bundle["damage"], this.damage.toInt())
                 .updateArmor(bundle["armor"], this.armor.toInt())
+
+            if (level >= 3) {
+                hud.statsWidget.activateSkill(0)
+            }
+        }
+
+        if (player.abilityCmp.hasAbility(FireballEffect)) {
+            hud.skillButton.style =
+                hud.skin.get(
+                    ImageButtonStyles.FIREBALL.name,
+                    ImageButton.ImageButtonStyle::class.java
+                )
         }
     }
 
@@ -185,14 +197,6 @@ class GameScreen(
 
             player.abilityCmp.run {
                 this.abilityToCastIdx = saveState.abilityToCastIdx
-                if (this.abilityToCastIdx == 0) {
-                    hud.statsWidget.activateSkill(0)
-                    hud.skillButton.style =
-                        hud.skin.get(
-                            ImageButtonStyles.FIREBALL.name,
-                            ImageButton.ImageButtonStyle::class.java
-                        )
-                }
                 saveState.abilities.forEach {
                     this.addAbility(player, it)
                 }

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/GameScreen.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/GameScreen.kt
@@ -4,6 +4,7 @@ import box2dLight.RayHandler
 import com.badlogic.ashley.core.Engine
 import com.badlogic.ashley.core.Entity
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.Preferences
 import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.graphics.glutils.FrameBuffer
@@ -20,12 +21,16 @@ import com.github.quillraven.quillysadventure.audio.AudioService
 import com.github.quillraven.quillysadventure.drawTransitionFBOs
 import com.github.quillraven.quillysadventure.ecs.component.PlayerComponent
 import com.github.quillraven.quillysadventure.ecs.component.abilityCmp
+import com.github.quillraven.quillysadventure.ecs.component.playerCmp
 import com.github.quillraven.quillysadventure.ecs.component.statsCmp
 import com.github.quillraven.quillysadventure.ecs.system.DeathSystem
 import com.github.quillraven.quillysadventure.ecs.system.FloatingTextSystem
+import com.github.quillraven.quillysadventure.ecs.system.KEY_SAVE_STATE
 import com.github.quillraven.quillysadventure.ecs.system.LightSystem
 import com.github.quillraven.quillysadventure.ecs.system.RenderSystem
+import com.github.quillraven.quillysadventure.ecs.system.SaveState
 import com.github.quillraven.quillysadventure.ecs.system.TutorialSystem
+import com.github.quillraven.quillysadventure.ecs.system.TutorialType
 import com.github.quillraven.quillysadventure.event.GameEventManager
 import com.github.quillraven.quillysadventure.event.Key
 import com.github.quillraven.quillysadventure.input.InputListener
@@ -33,6 +38,7 @@ import com.github.quillraven.quillysadventure.map.Map
 import com.github.quillraven.quillysadventure.map.MapChangeListener
 import com.github.quillraven.quillysadventure.map.MapManager
 import com.github.quillraven.quillysadventure.map.MapType
+import com.github.quillraven.quillysadventure.preferences
 import com.github.quillraven.quillysadventure.ui.GameHUD
 import com.github.quillraven.quillysadventure.ui.ImageButtonStyles
 import com.github.quillraven.quillysadventure.ui.Images
@@ -40,6 +46,9 @@ import ktx.app.KtxGame
 import ktx.app.KtxScreen
 import ktx.app.clearScreen
 import ktx.ashley.get
+import ktx.math.component1
+import ktx.math.component2
+import ktx.preferences.get
 
 class GameScreen(
     private val game: KtxGame<KtxScreen>,
@@ -51,7 +60,8 @@ class GameScreen(
     rayHandler: RayHandler,
     viewport: Viewport,
     stage: Stage,
-    private val batch: Batch = stage.batch
+    private val batch: Batch = stage.batch,
+    private val preferences: Preferences = Gdx.app.preferences
 ) : Screen(engine, audioService, bundle, stage, gameEventManager, rayHandler, viewport), InputListener,
     MapChangeListener {
     private val hud = GameHUD(gameEventManager, bundle["statsTitle"], bundle["skills"])
@@ -87,6 +97,102 @@ class GameScreen(
         gameOver = false
 
         // setup game UI
+        setupGameUI()
+
+        // get save state to reset to last save state values
+        val saveState: SaveState? = preferences[KEY_SAVE_STATE]
+
+        // add game screen as input listener to react when the player wants to quit the game (=exit key pressed)
+        gameEventManager.addInputListener(this)
+        // add screen as MapChangeListener to show the map name information when changing maps
+        gameEventManager.addMapChangeListener(this)
+
+        // set initial map
+        initMapManager(saveState)
+
+        engine.addSystem(tutorialSystem)
+        // set player hud info (life, mana, attack ready, etc.)
+        engine.entities.forEach { entity ->
+            val playerCmp = entity[PlayerComponent.mapper]
+            if (playerCmp != null) {
+                initPlayerProperties(saveState, entity)
+                updatePlayerHUD(entity)
+            }
+        }
+    }
+
+    private fun updatePlayerHUD(entity: Entity) {
+        with(entity.statsCmp) {
+            hud.infoWidget.resetHudValues(this.life / this.maxLife, this.mana / this.maxMana)
+            hud.statsWidget.updateLevel(levelTxt, this.level)
+                .updateExperience(
+                    xpTxt,
+                    xpAbbreviation,
+                    this.xp,
+                    engine.getSystem(DeathSystem::class.java).getNeededExperience(this.level)
+                )
+                .updateLife(lifeTxt, this.life.toInt(), this.maxLife.toInt())
+                .updateMana(manaTxt, this.mana.toInt(), this.maxMana.toInt())
+                .updateDamage(bundle["damage"], this.damage.toInt())
+                .updateArmor(bundle["armor"], this.armor.toInt())
+        }
+    }
+
+    private fun initPlayerProperties(
+        saveState: SaveState?,
+        player: Entity
+    ) {
+        if (saveState != null) {
+            val statsCmp = player.statsCmp
+            statsCmp.damage = saveState.damage
+            statsCmp.life = saveState.life
+            statsCmp.maxLife = saveState.maxLife
+            statsCmp.mana = saveState.mana
+            statsCmp.maxMana = saveState.maxMana
+            statsCmp.armor = saveState.armor
+            statsCmp.level = saveState.level
+            statsCmp.xp = saveState.xp
+
+            player.abilityCmp.run {
+                this.abilityToCastIdx = saveState.abilityToCastIdx
+                if (this.abilityToCastIdx == 0) {
+                    hud.skillButton.style =
+                        hud.skin.get(
+                            ImageButtonStyles.FIREBALL.name,
+                            ImageButton.ImageButtonStyle::class.java
+                        )
+                }
+                saveState.abilities.forEach {
+                    this.addAbility(player, it)
+                }
+            }
+
+            val playerCmp = player.playerCmp
+            val (x, y) = saveState.checkpoint
+            playerCmp.checkpoint.set(x, y)
+            mapManager.movePlayer(x, y)
+            playerCmp.tutorials.clear()
+            for (i in 0 until saveState.tutorials.size) {
+                playerCmp.tutorials.add(TutorialType.values()[i])
+            }
+        }
+    }
+
+    private fun initMapManager(saveState: SaveState?) {
+        mapTransitionTime = maxMapTransitionTime
+        ignoreMapTransition = true
+        mapManager.mapEntityCache.clear()
+        if (saveState != null) {
+            saveState.mapEntities.forEach {
+                mapManager.storeMapEntities(MapType.values()[it.key], it.value)
+            }
+            mapManager.setMap(saveState.currentMap)
+        } else {
+            mapManager.setMap(MapType.MAP1)
+        }
+    }
+
+    private fun setupGameUI() {
         stage.addActor(hud)
         stage.addActor(hud.statsWidget.apply {
             addSkill(bundle["fireball"], bundle["requiresLvl3"], Images.IMAGE_FIREBALL)
@@ -107,37 +213,6 @@ class GameScreen(
                 }
             }
         })
-
-        // add game screen as input listener to react when the player wants to quit the game (=exit key pressed)
-        gameEventManager.addInputListener(this)
-        // add screen as MapChangeListener to show the map name information when changing maps
-        gameEventManager.addMapChangeListener(this)
-        // set initial map
-        mapTransitionTime = maxMapTransitionTime
-        ignoreMapTransition = true
-        mapManager.setMap(MapType.MAP1)
-
-        engine.addSystem(tutorialSystem)
-        // set player hud info (life, mana, attack ready, etc.)
-        engine.entities.forEach {
-            val playerCmp = it[PlayerComponent.mapper]
-            if (playerCmp != null) {
-                with(it.statsCmp) {
-                    hud.infoWidget.resetHudValues(this.life / this.maxLife, this.mana / this.maxMana)
-                    hud.statsWidget.updateLevel(levelTxt, this.level)
-                        .updateExperience(
-                            xpTxt,
-                            xpAbbreviation,
-                            this.xp,
-                            engine.getSystem(DeathSystem::class.java).getNeededExperience(this.level)
-                        )
-                        .updateLife(lifeTxt, this.life.toInt(), this.maxLife.toInt())
-                        .updateMana(manaTxt, this.mana.toInt(), this.maxMana.toInt())
-                        .updateDamage(bundle["damage"], this.damage.toInt())
-                        .updateArmor(bundle["armor"], this.armor.toInt())
-                }
-            }
-        }
     }
 
     override fun hide() {

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/LoadingScreen.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/LoadingScreen.kt
@@ -53,14 +53,12 @@ import com.github.quillraven.quillysadventure.ecs.system.PlayerInputSystem
 import com.github.quillraven.quillysadventure.ecs.system.RemoveSystem
 import com.github.quillraven.quillysadventure.ecs.system.RenderPhysicDebugSystem
 import com.github.quillraven.quillysadventure.ecs.system.RenderSystem
-import com.github.quillraven.quillysadventure.ecs.system.SaveSystem
 import com.github.quillraven.quillysadventure.ecs.system.StateSystem
 import com.github.quillraven.quillysadventure.ecs.system.TakeDamageSystem
 import com.github.quillraven.quillysadventure.ecs.system.TriggerSystem
 import com.github.quillraven.quillysadventure.event.GameEventManager
 import com.github.quillraven.quillysadventure.itemConfigurations
 import com.github.quillraven.quillysadventure.map.MapManager
-import com.github.quillraven.quillysadventure.preferences
 import com.github.quillraven.quillysadventure.ui.LabelStyles
 import com.github.quillraven.quillysadventure.ui.widget.LoadingBarWidget
 import ktx.actors.centerPosition
@@ -187,7 +185,6 @@ class LoadingScreen(
                 addSystem(LightSystem(rayHandler, gameViewport.camera as OrthographicCamera))
                 addSystem(FloatingTextSystem(batch, gameViewport, stage.viewport))
                 addSystem(RemoveSystem(this))
-                addSystem(SaveSystem(Gdx.app.preferences, mapManager))
             }
             // create player entity that is shown in the menu and used in the game
             ecsEngine.character(charCfgs[Character.PLAYER], world, 0f, 0f, 1) {

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/LoadingScreen.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/screen/LoadingScreen.kt
@@ -53,12 +53,14 @@ import com.github.quillraven.quillysadventure.ecs.system.PlayerInputSystem
 import com.github.quillraven.quillysadventure.ecs.system.RemoveSystem
 import com.github.quillraven.quillysadventure.ecs.system.RenderPhysicDebugSystem
 import com.github.quillraven.quillysadventure.ecs.system.RenderSystem
+import com.github.quillraven.quillysadventure.ecs.system.SaveSystem
 import com.github.quillraven.quillysadventure.ecs.system.StateSystem
 import com.github.quillraven.quillysadventure.ecs.system.TakeDamageSystem
 import com.github.quillraven.quillysadventure.ecs.system.TriggerSystem
 import com.github.quillraven.quillysadventure.event.GameEventManager
 import com.github.quillraven.quillysadventure.itemConfigurations
 import com.github.quillraven.quillysadventure.map.MapManager
+import com.github.quillraven.quillysadventure.preferences
 import com.github.quillraven.quillysadventure.ui.LabelStyles
 import com.github.quillraven.quillysadventure.ui.widget.LoadingBarWidget
 import ktx.actors.centerPosition
@@ -185,6 +187,7 @@ class LoadingScreen(
                 addSystem(LightSystem(rayHandler, gameViewport.camera as OrthographicCamera))
                 addSystem(FloatingTextSystem(batch, gameViewport, stage.viewport))
                 addSystem(RemoveSystem(this))
+                addSystem(SaveSystem(Gdx.app.preferences, mapManager))
             }
             // create player entity that is shown in the menu and used in the game
             ecsEngine.character(charCfgs[Character.PLAYER], world, 0f, 0f, 1) {

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/trigger/Trigger.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/trigger/Trigger.kt
@@ -26,9 +26,12 @@ import com.github.quillraven.quillysadventure.trigger.action.TriggerActionSelect
 import com.github.quillraven.quillysadventure.trigger.action.TriggerActionSetPlayerInput
 import com.github.quillraven.quillysadventure.trigger.action.TriggerActionShowDialog
 import com.github.quillraven.quillysadventure.trigger.action.TriggerActionWaitCreatedCharacterDeath
+import com.github.quillraven.quillysadventure.trigger.condition.TriggerCondition
+import com.github.quillraven.quillysadventure.trigger.condition.TriggerConditionIsEntityAlive
 import ktx.collections.iterate
 
 class Trigger : Pool.Poolable {
+    private val conditions = Array<TriggerCondition>(4)
     private val actions = Array<TriggerAction>(8)
     private var currentIdx = 0
     lateinit var activatingCharacter: Entity
@@ -40,6 +43,14 @@ class Trigger : Pool.Poolable {
         }
 
         return currentIdx >= actions.size
+    }
+
+    fun checkConditions(): Boolean {
+        conditions.forEach {
+            if (!it.evaluate()) return false
+        }
+
+        return true
     }
 
     override fun reset() {
@@ -193,6 +204,17 @@ class Trigger : Pool.Poolable {
         })
         return this
     }
+
+    fun conditions(condition: Trigger.() -> TriggerCondition): Trigger {
+        conditions.add(this.condition())
+        return this
+    }
+
+    fun isEntityDead(tmxMapID: Int): TriggerCondition =
+        ReflectionPool(TriggerConditionIsEntityAlive::class.java).obtain().apply {
+            this.tmxMapID = tmxMapID
+            this.checkAlive = false
+        }
 
     companion object {
         val pool = ReflectionPool(Trigger::class.java, 8)

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/trigger/TriggerMap2.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/trigger/TriggerMap2.kt
@@ -40,3 +40,17 @@ fun setupBossPitRight(trigger: Trigger) {
         .damageSelectedCharacter(3f)
         .deactivateTrigger(true)
 }
+
+/**
+ * This trigger is used if the game is loaded after the boss fight.
+ * It will activate the "Portal to Cave Top" portal and in the future
+ * create the path to the next map again
+ */
+@Suppress("unused")
+fun setupAfterBoss(trigger: Trigger) {
+    trigger.conditions {
+        isEntityDead(91)
+    }
+        .enablePortal(97)
+        .deactivateTrigger(true)
+}

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/trigger/condition/TriggerConditions.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/trigger/condition/TriggerConditions.kt
@@ -1,0 +1,42 @@
+package com.github.quillraven.quillysadventure.trigger.condition
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.utils.Pool
+import com.github.quillraven.quillysadventure.ecs.component.TmxMapComponent
+import com.github.quillraven.quillysadventure.ecsEngine
+import ktx.ashley.get
+
+interface TriggerCondition : Pool.Poolable {
+    fun evaluate(): Boolean
+
+    override fun reset() = Unit
+}
+
+class TriggerConditionIsEntityAlive : TriggerCondition {
+    private val engine = Gdx.app.ecsEngine
+    var tmxMapID = -1
+    var checkAlive = true
+
+    /**
+     * If [checkAlive] is **true** then this method returns true if and only if
+     * the entity of the given ID is **alive**.
+     *
+     * If [checkAlive] is **false** then this method returns true if and only if
+     * the entity of the given ID is **dead**.
+     */
+    override fun evaluate(): Boolean {
+        engine.entities.forEach {
+            val tmx = it[TmxMapComponent.mapper]
+            if (tmx?.id == tmxMapID) {
+                return checkAlive
+            }
+        }
+
+        return !checkAlive
+    }
+
+    override fun reset() {
+        tmxMapID = -1
+        checkAlive = true
+    }
+}

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ui/MenuHUD.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ui/MenuHUD.kt
@@ -52,11 +52,11 @@ class MenuHUD(
 
     init {
         background = skin[Images.MENU_BACKGROUND]
-        defaults().pad(5f, 70f, 5f, 25f)
+        defaults().pad(5f, 70f, 25f, 25f)
 
         newGameLabel = label(bundle["newGame"], LabelStyles.LARGE.name) { cell ->
             setAlignment(Align.center)
-            cell.fillX().row()
+            cell.fillX().padTop(25f).row()
         }
         continueLabel = label(bundle["continue"], LabelStyles.LARGE.name) { cell ->
             setAlignment(Align.center)

--- a/core/src/main/kotlin/com/github/quillraven/quillysadventure/ui/widget/ConfirmDialogWidget.kt
+++ b/core/src/main/kotlin/com/github/quillraven/quillysadventure/ui/widget/ConfirmDialogWidget.kt
@@ -1,0 +1,45 @@
+package com.github.quillraven.quillysadventure.ui.widget
+
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
+import com.badlogic.gdx.scenes.scene2d.ui.Skin
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.Align
+import com.github.quillraven.quillysadventure.ui.Images
+import com.github.quillraven.quillysadventure.ui.LabelStyles
+import com.github.quillraven.quillysadventure.ui.get
+import ktx.scene2d.Scene2DSkin
+
+class ConfirmDialogWidget(
+    infoTxt: String,
+    yesTxt: String,
+    noTxt: String,
+    skin: Skin = Scene2DSkin.defaultSkin
+) : Table(skin) {
+    private val textLabel = Label("[BLACK]$infoTxt[]", skin).apply {
+        setWrap(true)
+        setAlignment(Align.topLeft)
+    }
+    private val scrollPane = ScrollPane(textLabel, skin).apply {
+        width = 610f
+        height = 400f
+        setScrollbarsVisible(true)
+        fadeScrollBars = false
+        variableSizeKnobs = false
+    }
+    val yesLabel = Label(" [DARK_GRAY]$yesTxt[] ", skin, LabelStyles.LARGE.name)
+    val noLabel = Label(" [DARK_GRAY]$noTxt[] ", skin, LabelStyles.LARGE.name)
+
+    init {
+        background = skin[Images.DIALOG_LIGHT]
+        add(scrollPane).fill().size(610f, 300f).padTop(50f).padLeft(50f).colspan(2).row()
+
+        add(yesLabel).bottom().fill().padBottom(25f).padLeft(50f)
+        add(noLabel).bottom().fill().padBottom(25f)
+        pack()
+
+        // group is not rotated or scaled and therefore we do not need to transform every draw call
+        // -> increased draw performance because we avoid flushing the batch
+        isTransform = false
+    }
+}


### PR DESCRIPTION
Following things need to be done:
- [x] Test saving and loading of abilities. HUD should correctly show the fireball if it was skilled before
- [x] Test that the boss trigger is not executed again when loading a save after the fight
- [x] Save game when changing the map
- [x] Update Main Menu: Continue should only be allowed if there is a savestate and "New Game" should display a warning if a savestate exists. If the player wants to start new we need to delete the old saveState.
Also, make the padding between menu options bigger because currently it is not easy to select the correct choice on android.
- [x] Add the "X" close button to the game to allow android users to go back to the main menu
- [x] Add a warning when pressing the "X" button in game. Progress will be lost until the last checkpoint